### PR TITLE
Accept integers and other types as call arguments

### DIFF
--- a/doctl.py
+++ b/doctl.py
@@ -85,7 +85,7 @@ class DigitalOcean:
             args = list(args)
             args.extend(["--access-token", self.token])
 
-        args = " ".join(args)
+        args = " ".join(map(str, args))
         cmd = f"doctl {args}"
 
         logging.info(cmd)


### PR DESCRIPTION
Assume the following command:

```
  doctl compute droplet neighbors 42 --output json
```

Because in a CLI, everything is considered as a string, this call is just fine.
However, assume the following call in doctl:

```
  doctl.compute.droplet.neighbors(42)
```

This one will fail with the following error:

```
Traceback (most recent call last):
  File "main.py", line 114, in upgrade
    print(doctl.compute.droplet.neighbors(droplet['id']))
  File "/home/user/venv/lib/python3.6/site-packages/doctl.py", line 224, in neighbors
    return self.do.doctl("compute", "droplet", "neighbors", droplet_id)
  File "/home/user/venv/lib/python3.6/site-packages/doctl.py", line 82, in doctl
    args = " ".join(args)
TypeError: sequence item 3: expected str instance, int found
```

Apparently, 42 must be a string in order to work out. `str(42)` seems non-intuitive and therefore I propose this change.