### PR TITLE
Fix typo in domain create; make ip_address optional

### DIFF
--- a/doctl.py
+++ b/doctl.py
@@ -250,14 +250,11 @@ class ComputeDomain:
 
     def create(self, domain, ip_address=None):
         """Create domain."""
-        if ip_address != None:
-            return self.do.doctl(
-              "compute", "domain", "create", domain, "--ip-address", ip_address
-            )
-        else:
-            return self.do.doctl(
-              "compute", "domain", "create", domain
-            )
+        args = []
+        if ip_address:
+            args.extend(["--ip-address", ip_address])
+            
+        return self.do.doctl("compute", "domain", "create", domain, *args)
       
     def list(self):
         """List domain."""

--- a/doctl.py
+++ b/doctl.py
@@ -248,12 +248,17 @@ class ComputeDomain:
     def __init__(self, do):
         self.do = do
 
-    def create(self, domain, ip_address):
+    def create(self, domain, ip_address=None):
         """Create domain."""
-        return self.do.doctl(
-            "compute", "domain", create, domain, "--ip-address", ip_address
-        )
-
+        if ip_address != None:
+            return self.do.doctl(
+              "compute", "domain", "create", domain, "--ip-address", ip_address
+            )
+        else:
+            return self.do.doctl(
+              "compute", "domain", "create", domain
+            )
+      
     def list(self):
         """List domain."""
         return self.do.doctl("compute", "domain", "list")


### PR DESCRIPTION
* call to domain create was missing quotation marks around "create".
* ip_address is optional and should not be required by this wrapper.